### PR TITLE
Skips adding ssh keys when keys_to_add is null

### DIFF
--- a/roles/capistrano_setup/tasks/main.yml
+++ b/roles/capistrano_setup/tasks/main.yml
@@ -24,7 +24,7 @@
   authorized_key: user={{ capistrano_user }} key={{ item }} exclusive=no state=present
   with_items:
     - "{{ keys_to_add }}"
-  when: keys_to_add is defined
+  when: keys_to_add is defined and keys_to_add != None
 
 - name: allow capistrano user to restart resque-pool
   become: yes


### PR DESCRIPTION
vagrant_dev.yml somehow defines keys_to_add but as a null, which causes an error.
