### PR TITLE
Adds reasonable solr collection default

### DIFF
--- a/roles/hydra-stack/install/defaults/main.yml
+++ b/roles/hydra-stack/install/defaults/main.yml
@@ -17,3 +17,5 @@ app_root: /opt/{{ project_name }}/current
 fedora_version: 4.1.0
 #solr_version: 4.10.4
 solr_version: 5.5.0
+# Default solr collection
+solr_core: collection1


### PR DESCRIPTION
vagrant_dev.yml somehow defines keys_to_add but as a null, which causes an error.
